### PR TITLE
Maintaining a new index in the 0th file which has index for all the r…

### DIFF
--- a/src/diskmgr/bigDB.java
+++ b/src/diskmgr/bigDB.java
@@ -11,13 +11,12 @@ public class bigDB implements GlobalConst {
 
 
     private static final int bits_per_page = MAX_SPACE * 8;
-    public static PCounter pcounter;
 
 
     /**
      * Open the database with the given name.
      *
-     * @param name DB_name
+     * @param fname DB_name
      * @throws IOException                I/O errors
      * @throws FileIOException            file I/O error
      * @throws InvalidPageNumberException invalid page number
@@ -54,7 +53,6 @@ public class bigDB implements GlobalConst {
      * default constructor.
      */
     public bigDB() {
-        pcounter = new PCounter();
     }
 
     /**
@@ -62,8 +60,8 @@ public class bigDB implements GlobalConst {
      * Create a database with the specified number of pages where the page
      * size is the default page size.
      *
-     * @param name      DB name
-     * @param num_pages number of pages in DB
+     * @param fname      DB name
+     * @param num_pgs number of pages in DB
      * @throws IOException                I/O errors
      * @throws InvalidPageNumberException invalid page number
      * @throws FileIOException            file I/O error
@@ -157,7 +155,7 @@ public class bigDB implements GlobalConst {
         byte[] buffer = apage.getpage();  //new byte[MINIBASE_PAGESIZE];
         try {
             fp.read(buffer);
-            pcounter.readIncrement();
+            PCounter.readIncrement();
         } catch (IOException e) {
             throw new FileIOException(e, "DB file I/O error");
         }
@@ -187,7 +185,7 @@ public class bigDB implements GlobalConst {
         // Write the appropriate number of bytes.
         try {
             fp.write(apage.getpage());
-            pcounter.writeIncrement();
+            PCounter.writeIncrement();
         } catch (IOException e) {
             throw new FileIOException(e, "DB file I/O error");
         }
@@ -221,7 +219,7 @@ public class bigDB implements GlobalConst {
      * user specified run_size
      *
      * @param start_page_num the starting page id of the run of pages
-     * @param run_size       the number of page need allocated
+     * @param runsize       the number of page need allocated
      * @throws OutOfSpaceException        No space left
      * @throws InvalidRunSizeException    invalid run size
      * @throws InvalidPageNumberException invalid page number
@@ -239,7 +237,6 @@ public class bigDB implements GlobalConst {
 
         if (runsize < 0) throw new InvalidRunSizeException(null, "Negative run_size");
 
-        int run_size = runsize;
         int num_map_pages = (num_pages + bits_per_page - 1) / bits_per_page;
         int current_run_start = 0;
         int current_run_length = 0;
@@ -271,7 +268,7 @@ public class bigDB implements GlobalConst {
             // one steps through each byte's bits.
 
             for (; num_bits_this_page > 0
-                    && current_run_length < run_size; ++byteptr) {// start forloop02
+                    && current_run_length < runsize; ++byteptr) {// start forloop02
 
 
                 Integer intmask = new Integer(1);
@@ -279,7 +276,7 @@ public class bigDB implements GlobalConst {
                 byte tmpmask = mask.byteValue();
 
                 while (mask.intValue() != 0 && (num_bits_this_page > 0)
-                        && (current_run_length < run_size)) {
+                        && (current_run_length < runsize)) {
                     if ((pagebuf[byteptr] & tmpmask) != 0) {
                         current_run_start += current_run_length + 1;
                         current_run_length = 0;
@@ -299,9 +296,9 @@ public class bigDB implements GlobalConst {
 
         }// end of forloop01
 
-        if (current_run_length >= run_size) {
+        if (current_run_length >= runsize) {
             start_page_num.pid = current_run_start;
-            set_bits(start_page_num, run_size, 1);
+            set_bits(start_page_num, runsize, 1);
 
             return;
         }
@@ -338,7 +335,6 @@ public class bigDB implements GlobalConst {
      * with run size = 1
      *
      * @param start_page_num the start pageId to be deallocate
-     * @param run_size       the number of pages to be deallocated
      * @throws InvalidRunSizeException    invalid run size
      * @throws InvalidPageNumberException invalid page number
      * @throws FileIOException            file I/O error

--- a/src/index/MapIndexScanBigT.java
+++ b/src/index/MapIndexScanBigT.java
@@ -1,0 +1,380 @@
+package index;
+
+import BigT.Map;
+import BigT.Pair;
+import BigT.bigt;
+import btree.*;
+import global.AttrType;
+import global.IndexType;
+import global.MID;
+import heap.Heapfile;
+import heap.InvalidTupleSizeException;
+import heap.InvalidTypeException;
+import iterator.*;
+
+import java.io.IOException;
+import java.util.List;
+
+/**
+ * Index Scan iterator will directly access the required tuple using
+ * the provided key. It will also perform selections and projections.
+ * information about the tuples and the index are passed to the constructor,
+ * then the user calls <code>get_next()</code> to get the tuples.
+ */
+public class MapIndexScanBigT extends MapIterator{
+
+    public boolean closeFlag = false;
+
+    /**
+     * class constructor. set up the index scan.
+     *
+     * @param index     type of the index (B_Index, Hash)
+     * @param bigTable   name of the input relation
+     * @param indName   name of the input index
+     * @param types     array of types in this relation
+     * @param str_sizes array of string sizes (for attributes that are string)
+     * @param noInFlds  number of fields in input tuple
+     * @param noOutFlds number of fields in output tuple
+     * @param outFlds   fields to project
+     * @param selects   conditions to apply, first one is primary
+     * @param fldNum    field number of the indexed field
+     * @param indexOnly whether the answer requires only the key or the tuple
+     * @throws IndexException            error from the lower layer
+     * @throws InvalidTypeException      tuple type not valid
+     * @throws InvalidTupleSizeException tuple size not valid
+     * @throws UnknownIndexTypeException index type unknown
+     * @throws IOException               from the lower layer
+     */
+    public MapIndexScanBigT(
+            IndexType index,
+            final bigt bigTable,
+            final String indName,
+            AttrType types[],
+            short str_sizes[],
+            int noInFlds,
+            int noOutFlds,
+            FldSpec outFlds[],
+            CondExpr selects[],
+            CondExpr selectForKey[],
+            final int fldNum,
+            final boolean indexOnly
+    )
+            throws IndexException,
+            InvalidTypeException,
+            InvalidTupleSizeException,
+            UnknownIndexTypeException,
+            IOException {
+        _fldNum = fldNum;
+        _noInFlds = noInFlds;
+        _types = types;
+        _s_sizes = str_sizes;
+
+        AttrType[] Jtypes = new AttrType[noOutFlds];
+        short[] ts_sizes;
+        Jtuple = new Map();
+
+
+        try {
+            ts_sizes = MapUtils.setup_op_map(Jtuple, Jtypes, types, noInFlds, str_sizes, outFlds, noOutFlds);
+        } catch (TupleUtilsException e) {
+            throw new IndexException(e, "IndexScan.java: TupleUtilsException caught from TupleUtils.setup_op_tuple()");
+        } catch (InvalidRelation e) {
+            throw new IndexException(e, "IndexScan.java: InvalidRelation caught from TupleUtils.setup_op_tuple()");
+        }
+
+        _selects = selects;
+        _select_for_key = selectForKey;
+        perm_mat = outFlds;
+        _noOutFlds = noOutFlds;
+        map1 = new Map();
+        try {
+            map1.setDefaultHdr();
+        } catch (Exception e) {
+            throw new IndexException(e, "IndexScan.java: Heapfile error");
+        }
+
+        t1_size = map1.size();
+        index_only = indexOnly;  // added by bingjie miao
+
+        try {
+            this.heapfiles = bigTable.heapFiles;
+        } catch (Exception e) {
+            throw new IndexException(e, "IndexScan.java: Heapfile not created");
+        }
+
+        switch (index.indexType) {
+            // linear hashing is not yet implemented
+            case IndexType.B_Index:
+                // error check the select condition
+                // must be of the type: value op symbol || symbol op value
+                // but not symbol op symbol || value op value
+                try {
+                    indFile = new BTreeFile(indName);
+                } catch (Exception e) {
+                    throw new IndexException(e, "IndexScan.java: BTreeFile exceptions caught from BTreeFile constructor");
+                }
+
+                try {
+
+                    indScan = IndexUtils.BTree_scan(_select_for_key, indFile);
+                } catch (Exception e) {
+                    throw new IndexException(e, "IndexScan.java: BTreeFile exceptions caught from IndexUtils.BTree_scan().");
+                }
+
+                break;
+            case IndexType.None:
+            default:
+                throw new UnknownIndexTypeException("Only BTree index is supported so far");
+
+        }
+
+    }
+
+    /**
+     * returns the next tuple.
+     * if <code>index_only</code>, only returns the key value
+     * (as the first field in a tuple)
+     * otherwise, retrive the tuple and returns the whole tuple
+     *
+     * @return the tuple
+     * @throws IndexException          error from the lower layer
+     * @throws UnknownKeyTypeException key type unknown
+     * @throws IOException             from the lower layer
+     */
+    public Map get_next()
+            throws IndexException,
+            UnknownKeyTypeException,
+            IOException {
+        MID mid;
+        int unused;
+        KeyDataEntry nextentry = null;
+
+        try {
+            nextentry = indScan.get_next();
+        } catch (Exception e) {
+            throw new IndexException(e, "IndexScan.java: BTree error");
+        }
+
+        while (nextentry != null) {
+            if (index_only) {
+
+                // only need to return the key
+
+                AttrType[] attrType = new AttrType[1];
+                short[] s_sizes = new short[1];
+
+                if (_types[_fldNum - 1].attrType == AttrType.attrInteger) {
+                    attrType[0] = new AttrType(AttrType.attrInteger);
+                    try {
+                        Jtuple.setHdr((short) 1, attrType, s_sizes);
+                    } catch (Exception e) {
+                        throw new IndexException(e, "IndexScan.java: Heapfile error");
+                    }
+
+                    try {
+                        Jtuple.setIntFld(1, ((IntegerKey) nextentry.key).getKey().intValue());
+                    } catch (Exception e) {
+                        throw new IndexException(e, "IndexScan.java: Heapfile error");
+                    }
+                } else if (_types[_fldNum - 1].attrType == AttrType.attrString) {
+
+                    attrType[0] = new AttrType(AttrType.attrString);
+                    // calculate string size of _fldNum
+                    int count = 0;
+                    for (int i = 0; i < _fldNum; i++) {
+                        if (_types[i].attrType == AttrType.attrString)
+                            count++;
+                    }
+                    s_sizes[0] = _s_sizes[count - 1];
+
+                    try {
+                        Jtuple.setHdr((short) 1, attrType, s_sizes);
+                    } catch (Exception e) {
+                        throw new IndexException(e, "IndexScan.java: Heapfile error");
+                    }
+
+                    try {
+                        Jtuple.setStrFld(1, ((StringKey) nextentry.key).getKey());
+                    } catch (Exception e) {
+                        throw new IndexException(e, "IndexScan.java: Heapfile error");
+                    }
+                } else {
+                    // attrReal not supported for now
+                    throw new UnknownKeyTypeException("Only Integer and String keys are supported so far");
+                }
+                return Jtuple;
+            }
+
+            // not index_only, need to return the whole tuple
+            mid = ((LeafData) nextentry.data).getData();
+
+            for (int i = 1; i < heapfiles.size(); i++) {
+                try {
+                    map1 = heapfiles.get(i).getRecordMap(mid);
+                    if (map1 != null) {
+                        break;
+                    }
+                } catch (Exception e) {
+                    if (i == 5)
+                        throw new IndexException(e, "IndexScan.java: getRecord failed");
+                }
+            }
+
+            if(map1!=null){
+                try {
+                    map1.setFldOffset(map1.getMapByteArray());
+                } catch (Exception e) {
+                    throw new IndexException("IndexScan.java Exception: Unable to set map fldOffset");
+                }
+                boolean eval;
+                try {
+                    eval = PredEval.Eval(_selects, map1, null, _types, null);
+                } catch (Exception e) {
+                    throw new IOException("");
+                }
+                if (eval) {
+                    return map1;
+                }
+            }
+
+            try {
+                nextentry = indScan.get_next();
+            } catch (Exception e) {
+                throw new IndexException(e, "IndexScan.java: BTree error");
+            }
+        }
+
+        return null;
+    }
+
+
+    public Pair get_next_mid()
+            throws IndexException,
+            UnknownKeyTypeException,
+            IOException {
+        MID mid;
+        int unused;
+        String indexKey = "";
+        KeyDataEntry nextentry = null;
+        int heapFileIndex = -1;
+
+        try {
+            nextentry = indScan.get_next();
+        } catch (Exception e) {
+            throw new IndexException(e, "IndexScan.java: BTree error");
+        }
+
+        while (nextentry != null) {
+            if (index_only) {
+
+                // only need to return the key
+
+                AttrType[] attrType = new AttrType[1];
+                short[] s_sizes = new short[1];
+
+                if (_types[_fldNum - 1].attrType == AttrType.attrString) {
+
+                    indexKey = ((StringKey) nextentry.key).getKey();
+                    mid = ((LeafData) nextentry.data).getData();
+
+                } else {
+                    // attrReal not supported for now
+                    throw new UnknownKeyTypeException("Only Integer and String keys are supported so far");
+                }
+                return new Pair(null, mid, indexKey);
+            }
+
+            // not index_only, need to return the whole tuple
+            mid = ((LeafData) nextentry.data).getData();
+            for (int i = 1; i < heapfiles.size(); i++) {
+//                try {
+//                    map1 = heapfiles.get(i).getRecordMap(mid);
+//                    heapFileIndex = i;
+//                    break;
+//                } catch (Exception e) {
+//                    if (i == 5)
+//                        throw new IndexException(e, "IndexScan.java: getRecord failed");
+//                }
+                try {
+                    map1 = heapfiles.get(i).getRecordMap(mid);
+                    if (map1 != null) {
+                        heapFileIndex = i;
+                        break;
+                    }
+                } catch (Exception e) {
+                    if (i == 5)
+                        throw new IndexException(e, "IndexScan.java: getRecord failed");
+                }
+            }
+
+            if(map1 != null){
+                try {
+                    map1.setFldOffset(map1.getMapByteArray());
+                } catch (Exception e) {
+                    throw new IndexException("IndexScan.java Exception: Unable to set map fldOffset");
+                }
+
+                boolean eval;
+                try {
+                    eval = PredEval.Eval(_selects, map1, null, _types, null);
+                } catch (Exception e) {
+                    throw new IndexException(e, "IndexScan.java: Heapfile error");
+                }
+                if (eval) {
+                    return new Pair(map1, mid, null, heapFileIndex);
+                }
+            }
+
+            try {
+                nextentry = indScan.get_next();
+            } catch (Exception e) {
+                throw new IndexException(e, "IndexScan.java: BTree error");
+            }
+        }
+
+        return null;
+    }
+
+
+    /**
+     * Cleaning up the index scan, does not remove either the original
+     * relation or the index from the database.
+     *
+     * @throws IndexException error from the lower layer
+     * @throws IOException    from the lower layer
+     */
+    public void close() throws IOException, IndexException {
+        if (!closeFlag) {
+            if (indScan instanceof BTFileScan) {
+                try {
+                    ((BTFileScan) indScan).DestroyBTreeFileScan();
+                } catch (Exception e) {
+                    throw new IndexException(e, "BTree error in destroying index scan.");
+                }
+            }
+
+            closeFlag = true;
+        }
+    }
+
+    public void set_selects(CondExpr[] exprs){
+        _selects = exprs;
+    }
+
+    public FldSpec[] perm_mat;
+    private IndexFile indFile;
+    private IndexFileScan indScan;
+    private AttrType[] _types;
+    private short[] _s_sizes;
+    private CondExpr[] _selects;
+    private CondExpr[] _select_for_key;
+    private int _noInFlds;
+    private int _noOutFlds;
+    private List<Heapfile> heapfiles;
+    private Map map1;
+    private Map Jtuple;
+    private int t1_size;
+    private int _fldNum;
+    private boolean index_only;
+
+}

--- a/src/test_datarep.csv
+++ b/src/test_datarep.csv
@@ -1,0 +1,1 @@
+Denmark,Magpie,95814,97078

--- a/src/xyz.csv
+++ b/src/xyz.csv
@@ -1,0 +1,5 @@
+Denmark,Magpie,084814,01160
+Denmark,Magpie,061340,00001
+Denmark,Magpie,039190,05877
+Denmark,Magpie,071291,07078
+Denmark,Magpie,039846,09806


### PR DESCRIPTION
…ecords in the table. Adding the records to the heap file of the type and index directly during the batch insert and then later going over the maps and deleting the maps that are over 3 with same row and column label to maintain just 3 latest ones. Added a new class called MapIndexScanBigT.java to do the scan. This scan go overs all the heap files for the specified index.Added 2 test cs files test_datarep.csv and xyz.csv. Make the inference static in bigDB.java